### PR TITLE
Avoid NullPointerExc if theme doesn't have an ActionBar

### DIFF
--- a/library/src/main/java/net/rdrei/android/dirchooser/DirectoryChooserActivity.java
+++ b/library/src/main/java/net/rdrei/android/dirchooser/DirectoryChooserActivity.java
@@ -151,8 +151,9 @@ public class DirectoryChooserActivity extends Activity {
 
     /* package */void setupActionBar() {
     	// there might not be an ActionBar, for example when started in Theme.Holo.Dialog.NoActionBar theme
-    	if (getActionBar() != null)
+    	if (getActionBar() != null) {
         	getActionBar().setDisplayHomeAsUpEnabled(true);
+    	}
     }
 
     private void debug(String message, Object... args) {


### PR DESCRIPTION
App crashed (NullPointerException) when activity theme was set to Theme.Holo.Dialog.NoActionBar
