### PR TITLE
fix(library): check dir before writing outState

### DIFF
--- a/library/src/main/java/net/rdrei/android/dirchooser/DirectoryChooserFragment.java
+++ b/library/src/main/java/net/rdrei/android/dirchooser/DirectoryChooserFragment.java
@@ -100,7 +100,9 @@ public class DirectoryChooserFragment extends DialogFragment {
     public void onSaveInstanceState(@Nonnull Bundle outState) {
         super.onSaveInstanceState(outState);
 
-        outState.putString(KEY_CURRENT_DIRECTORY, mSelectedDir.getAbsolutePath());
+        if (mSelectedDir != null) {
+            outState.putString(KEY_CURRENT_DIRECTORY, mSelectedDir.getAbsolutePath());
+        }
     }
 
     @Override


### PR DESCRIPTION
Check whether mSelectedDir was set before saving the directory in
onSaveInstanceState in case that the fragment is detached very quickly.

Fix #20
