### PR TITLE
Fixed selected dir not being displayed

### DIFF
--- a/library/src/main/res/layout-v11/directory_chooser.xml
+++ b/library/src/main/res/layout-v11/directory_chooser.xml
@@ -82,7 +82,7 @@
             android:layout_below="@id/txtvSelectedFolderLabel"
             android:layout_toRightOf="@id/btnNavUp"
             android:layout_toLeftOf="@+id/btnCreateFolder"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:ellipsize="start"
             android:scrollHorizontally="true"

--- a/library/src/main/res/layout/directory_chooser.xml
+++ b/library/src/main/res/layout/directory_chooser.xml
@@ -59,7 +59,7 @@
 
         <TextView
                 android:id="@+id/txtvSelectedFolder"
-                android:layout_width="0dp"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_below="@id/txtvSelectedFolderLabel"
                 android:layout_toRightOf="@id/btnNavUp"


### PR DESCRIPTION
When tapping on a folder, the "selected dir" label wasn't being displayed
