### PR TITLE
Update DirectoryChooserFragment.java

### DIFF
--- a/library/src/main/java/net/rdrei/android/dirchooser/DirectoryChooserFragment.java
+++ b/library/src/main/java/net/rdrei/android/dirchooser/DirectoryChooserFragment.java
@@ -211,7 +211,7 @@ public class DirectoryChooserFragment extends DialogFragment {
         mListDirectories.setAdapter(mListDirectoriesAdapter);
 
         final File initialDir;
-        if (mInitialDirectory != null && isValidFile(new File(mInitialDirectory))) {
+        if (mInitialDirectory != null && new File(mInitialDirectory).exists() && new File(mInitialDirectory).isDirectory()) {
             initialDir = new File(mInitialDirectory);
         } else {
             initialDir = Environment.getExternalStorageDirectory();


### PR DESCRIPTION
When create a new instance specifing initial directory  the path is ignored 

Ex.
DirectoryChooserFragment.newInstance("DialogSample", "/storage");

It is because the validation fails if it is a directory.