### PR TITLE
feat(lib): immutable object for config

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,16 @@ You need to declare the `DirectoryChooserActivity` and request the
 To choose a directory, start the activity from your app logic:
 
 ```java
+
 final Intent chooserIntent = new Intent(this, DirectoryChooserActivity.class);
 
-// Optional: Allow users to create a new directory with a fixed name.
-chooserIntent.putExtra(DirectoryChooserActivity.EXTRA_NEW_DIR_NAME,
-                       "DirChooserSample");
+final DirectoryChooserConfig config = DirectoryChooserConfig.builder()
+        .newDirectoryName("DirChooserSample")
+        .allowReadOnlyDirectory(true)
+        .allowNewDirectoryNameModification(true)
+        .build();
+
+chooserIntent.putExtra(DirectoryChooserActivity.EXTRA_CONFIG, config);
 
 // REQUEST_DIRECTORY is a constant integer to identify the request, e.g. 0
 startActivityForResult(chooserIntent, REQUEST_DIRECTORY);
@@ -162,7 +167,10 @@ public class DirChooserFragmentSample extends Activity implements
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.dialog);
-        mDialog = DirectoryChooserFragment.newInstance("DialogSample", null);
+        final DirectoryChooserConfig config = DirectoryChooserConfig.builder()
+                .newDirectoryName("DialogSample")
+                .build();
+        mDialog = DirectoryChooserFragment.newInstance(config);
 
         mDirectoryTextView = (TextView) findViewById(R.id.textDirectory);
 
@@ -176,7 +184,7 @@ public class DirChooserFragmentSample extends Activity implements
     }
 
     @Override
-    public void onSelectDirectory(@Nonnull String path) {
+    public void onSelectDirectory(@NonNull String path) {
         mDirectoryTextView.setText(path);
         mDialog.dismiss();
     }
@@ -187,6 +195,44 @@ public class DirChooserFragmentSample extends Activity implements
     }
 }
 
+```
+
+### Configuration
+
+The Directory Chooser is configured through a parcelable configuration object, which is great
+because it means that you don't have to tear your hair out over finicky string extras. Instead,
+you get auto-completion and a nice immutable data structure. Here's what you can configure:
+
+#### `newDirectoryName` : String (required)
+
+Name of the directory to create. User can change this name when he creates the
+folder. To avoid this use `allowNewDirectoryNameModification` argument.
+
+#### `initialDirectory` : String (default: "")
+
+Optional argument to define the path of the directory that will be shown first.
+If it is not sent or if path denotes a non readable/writable directory or it is not a directory,
+it defaults to `android.os.Environment#getExternalStorageDirectory()`.
+
+#### `allowReadOnlyDirectory` : Boolean (default: false)
+
+Argument to define whether or not the directory chooser allows read-only paths to be chosen. If it
+false only directories with read-write access can be chosen.
+
+#### `allowNewDirectoryNameModification` : Boolean (default: false)
+
+Argument to define whether or not the directory chooser allows modification of provided new
+directory name.
+
+#### Example
+
+```java
+final DirectoryChooserConfig config = DirectoryChooserConfig.builder()
+        .newDirectoryName("DialogSample")
+        .allowNewDirectoryNameModification(true)
+        .allowReadOnlyDirectory(true)
+        .initialDirectory("/sdcard")
+        .build();
 ```
 
 ## Apps using this
@@ -273,7 +319,7 @@ gradle build :library:uploadArchives
 ## License
 
 ```text
-Copyright 2013-2014 Pascal Hartig
+Copyright 2013-2015 Pascal Hartig
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         mavenCentral()
+        jcenter()
         maven {
             url 'https://oss.sonatype.org/content/repositories/snapshots/'
         }
@@ -8,5 +9,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.neenbedankt.gradle.plugins:android-apt:1.4'
     }
 }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'com.neenbedankt.android-apt'
 apply plugin: 'checkstyle'
 
 repositories {
@@ -10,6 +11,10 @@ dependencies {
     compile 'com.android.support:appcompat-v7:22.2.1'
     compile 'com.android.support:support-annotations:22.2.1'
     compile 'com.gu:option:1.3'
+    compile 'com.github.frankiesardo:auto-parcel:0.3'
+    compile 'com.google.auto.value:auto-value:1.1'
+    apt 'com.github.frankiesardo:auto-parcel-processor:0.3'
+
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-all:1.9.5'
     testCompile('com.squareup:fest-android:1.0.8') {

--- a/library/src/main/java/net/rdrei/android/dirchooser/DirectoryChooserActivity.java
+++ b/library/src/main/java/net/rdrei/android/dirchooser/DirectoryChooserActivity.java
@@ -16,43 +16,26 @@ import android.view.MenuItem;
  */
 public class DirectoryChooserActivity extends AppCompatActivity implements
         DirectoryChooserFragment.OnFragmentInteractionListener {
-    public static final String EXTRA_NEW_DIR_NAME = "directory_name";
-    public static final String EXTRA_ALLOW_NEW_DIR_NAME_MODIFICIATION = "allow_directory_name_modification";
-
-    /**
-     * Extra to define the path of the directory that will be shown first.
-     * If it is not sent or if path denotes a non readable/writable directory
-     * or it is not a directory, it defaults to
-     * {@link android.os.Environment#getExternalStorageDirectory()}
-     */
-    public static final String EXTRA_INITIAL_DIRECTORY = "initial_directory";
-
+    public static final String EXTRA_CONFIG = "config";
     public static final String RESULT_SELECTED_DIR = "selected_dir";
     public static final int RESULT_CODE_DIR_SELECTED = 1;
-
-    public static final String EXTRA_ALLOW_READ_ONLY_DIRECTORY = "allow_read_only_directory";
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setupActionBar();
-
         setContentView(R.layout.directory_chooser_activity);
 
-        final String newDirName = getIntent().getStringExtra(EXTRA_NEW_DIR_NAME);
-        final String initialDir = getIntent().getStringExtra(EXTRA_INITIAL_DIRECTORY);
-        final boolean allowReadOnlyDir = getIntent().getBooleanExtra(EXTRA_ALLOW_READ_ONLY_DIRECTORY, false);
-        final boolean allowNewDirNameModification = getIntent().getBooleanExtra(EXTRA_ALLOW_NEW_DIR_NAME_MODIFICIATION, true);
+        final DirectoryChooserConfig config = getIntent().getParcelableExtra(EXTRA_CONFIG);
 
-        if (newDirName == null) {
+        if (config == null) {
             throw new IllegalArgumentException(
-                    "You must provide EXTRA_NEW_DIR_NAME when starting the DirectoryChooserActivity.");
+                    "You must provide EXTRA_CONFIG when starting the DirectoryChooserActivity.");
         }
 
         if (savedInstanceState == null) {
             final FragmentManager fragmentManager = getFragmentManager();
-            final DirectoryChooserFragment fragment = DirectoryChooserFragment.newInstance(newDirName, initialDir,
-                    allowReadOnlyDir, allowNewDirNameModification);
+            final DirectoryChooserFragment fragment = DirectoryChooserFragment.newInstance(config);
             fragmentManager.beginTransaction()
                     .add(R.id.main, fragment)
                     .commit();

--- a/library/src/main/java/net/rdrei/android/dirchooser/DirectoryChooserConfig.java
+++ b/library/src/main/java/net/rdrei/android/dirchooser/DirectoryChooserConfig.java
@@ -1,0 +1,56 @@
+package net.rdrei.android.dirchooser;
+
+import android.os.Parcelable;
+
+import auto.parcel.AutoParcel;
+
+@AutoParcel
+public abstract class DirectoryChooserConfig implements Parcelable {
+    /**
+     * @return Builder for a new DirectoryChooserConfig.
+     */
+    public static Builder builder() {
+        return new AutoParcel_DirectoryChooserConfig.Builder()
+                .initialDirectory("")
+                .allowNewDirectoryNameModification(false)
+                .allowReadOnlyDirectory(false);
+    }
+
+    /**
+     * Name of the directory to create. User can change this name when he creates the
+     * folder. To avoid this use {@link #allowNewDirectoryNameModification} argument.
+     */
+    abstract String newDirectoryName();
+
+    /**
+     * Optional argument to define the path of the directory
+     * that will be shown first.
+     * If it is not sent or if path denotes a non readable/writable directory
+     * or it is not a directory, it defaults to
+     * {@link android.os.Environment#getExternalStorageDirectory()}
+     */
+    abstract String initialDirectory();
+
+    /**
+     * Argument to define whether or not the directory chooser
+     * allows read-only paths to be chosen. If it false only
+     * directories with read-write access can be chosen.
+     */
+    abstract boolean allowReadOnlyDirectory();
+
+
+    /**
+     * Argument to define whether or not the directory chooser
+     * allows modification of provided new directory name.
+     */
+    abstract boolean allowNewDirectoryNameModification();
+
+    @AutoParcel.Builder
+    public abstract static class Builder {
+        public abstract Builder newDirectoryName(String s);
+        public abstract Builder initialDirectory(String s);
+        public abstract Builder allowReadOnlyDirectory(boolean b);
+        public abstract Builder allowNewDirectoryNameModification(boolean b);
+        public abstract DirectoryChooserConfig build();
+    }
+}

--- a/library/src/test/java/net/rdrei/android/dirchooser/DirectoryChooserActivityTest.java
+++ b/library/src/test/java/net/rdrei/android/dirchooser/DirectoryChooserActivityTest.java
@@ -30,8 +30,11 @@ public class DirectoryChooserActivityTest {
 
     @Test
     public void testSmokeInitWithExtras() {
-        launchIntent.putExtra(DirectoryChooserActivity.EXTRA_NEW_DIR_NAME,
-                "my dir");
+        final DirectoryChooserConfig config = DirectoryChooserConfig.builder()
+                .newDirectoryName("my dir")
+                .build();
+        launchIntent.putExtra(DirectoryChooserActivity.EXTRA_CONFIG,
+                config);
         activity.onCreate(null);
     }
 }

--- a/library/src/test/java/net/rdrei/android/dirchooser/DirectoryChooserFragmentTest.java
+++ b/library/src/test/java/net/rdrei/android/dirchooser/DirectoryChooserFragmentTest.java
@@ -53,8 +53,8 @@ public class DirectoryChooserFragmentTest {
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     @Test
     public void testWithDirectory() {
-        final DirectoryChooserFragment fragment = DirectoryChooserFragment.newInstance("mydir",
-                null);
+        final DirectoryChooserFragment fragment = DirectoryChooserFragment.newInstance(
+                DirectoryChooserConfig.builder().newDirectoryName("mydir").build());
 
         startFragment(fragment, DirectoryChooserActivityMock.class);
 
@@ -69,7 +69,12 @@ public class DirectoryChooserFragmentTest {
     public void testCreateDirectoryDialogAllowFolderNameModification() {
         final String directoryName = "mydir";
         final DirectoryChooserFragment fragment = DirectoryChooserFragment.newInstance(
-                directoryName, null, false, true);
+                DirectoryChooserConfig.builder()
+                        .newDirectoryName(directoryName)
+                        .initialDirectory("")
+                        .allowReadOnlyDirectory(false)
+                        .allowNewDirectoryNameModification(true)
+                        .build());
 
         startFragment(fragment, DirectoryChooserActivityMock.class);
 
@@ -97,7 +102,12 @@ public class DirectoryChooserFragmentTest {
     public void testCreateDirectoryDialogDisallowFolderNameModification() {
         final String directoryName = "mydir";
         final DirectoryChooserFragment fragment = DirectoryChooserFragment.newInstance(
-                directoryName, null, false, false);
+                DirectoryChooserConfig.builder()
+                        .newDirectoryName(directoryName)
+                        .initialDirectory("")
+                        .allowReadOnlyDirectory(false)
+                        .allowNewDirectoryNameModification(false)
+                        .build());
 
         startFragment(fragment, DirectoryChooserActivityMock.class);
 
@@ -123,8 +133,8 @@ public class DirectoryChooserFragmentTest {
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     @Test
     public void testWithCustomListener() {
-        final DirectoryChooserFragment fragment = DirectoryChooserFragment.newInstance("mydir",
-                null);
+        final DirectoryChooserFragment fragment = DirectoryChooserFragment.newInstance(
+                DirectoryChooserConfig.builder().newDirectoryName("mydir").build());
 
         startFragment(fragment, CustomDirectoryChooserActivity.class);
         final CustomDirectoryChooserListener listener = new CustomDirectoryChooserListener();

--- a/sample/src/main/java/net/rdrei/android/dirchooser/sample/DirChooserFragmentSample.java
+++ b/sample/src/main/java/net/rdrei/android/dirchooser/sample/DirChooserFragmentSample.java
@@ -7,6 +7,7 @@ import android.support.annotation.Nullable;
 import android.view.View;
 import android.widget.TextView;
 
+import net.rdrei.android.dirchooser.DirectoryChooserConfig;
 import net.rdrei.android.dirchooser.DirectoryChooserFragment;
 
 
@@ -19,7 +20,10 @@ public class DirChooserFragmentSample extends Activity implements DirectoryChoos
     protected void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.dialog);
-        mDialog = DirectoryChooserFragment.newInstance("DialogSample", null);
+        final DirectoryChooserConfig config = DirectoryChooserConfig.builder()
+                .newDirectoryName("DialogSample")
+                .build();
+        mDialog = DirectoryChooserFragment.newInstance(config);
 
         mDirectoryTextView = (TextView) findViewById(R.id.textDirectory);
 
@@ -41,6 +45,5 @@ public class DirChooserFragmentSample extends Activity implements DirectoryChoos
     @Override
     public void onCancelChooser() {
         mDialog.dismiss();
-
     }
 }

--- a/sample/src/main/java/net/rdrei/android/dirchooser/sample/DirChooserSample.java
+++ b/sample/src/main/java/net/rdrei/android/dirchooser/sample/DirChooserSample.java
@@ -9,6 +9,7 @@ import android.view.View.OnClickListener;
 import android.widget.TextView;
 
 import net.rdrei.android.dirchooser.DirectoryChooserActivity;
+import net.rdrei.android.dirchooser.DirectoryChooserConfig;
 
 public class DirChooserSample extends Activity {
     private static final int REQUEST_DIRECTORY = 0;
@@ -35,9 +36,15 @@ public class DirChooserSample extends Activity {
                                 DirChooserSample.this,
                                 DirectoryChooserActivity.class);
 
+                        final DirectoryChooserConfig config = DirectoryChooserConfig.builder()
+                                .newDirectoryName("DirChooserSample")
+                                .allowReadOnlyDirectory(true)
+                                .allowNewDirectoryNameModification(true)
+                                .build();
+
                         chooserIntent.putExtra(
-                                DirectoryChooserActivity.EXTRA_NEW_DIR_NAME,
-                                "DirChooserSample");
+                                DirectoryChooserActivity.EXTRA_CONFIG,
+                                config);
 
                         startActivityForResult(chooserIntent, REQUEST_DIRECTORY);
                     }


### PR DESCRIPTION
    This change makes use of Google AutoValue and AutoParcelable to move the
    previously stringly-typed configuration of the DirectoryChooser for both
    the Fragment and the Activity to an immutable object.

    There are a lot of benefits to this:

    - No more EXTRA_* strings. They are the worst. They disable type-safety,
      they take up permgen space, they make me angry.
    - Concise constructor. We had four arguments, two of them positional
      booleans. My pain threshold is one boolean and only if it's the only
      parameter. Now it's one clearly defined object.
    - Auto-generated Builder. AutoValue is really smart and automatically
      checks for nulls, or undefined required values. It's very smart about
      this and tracks this in a BitMap.
    - Auto-completion. You get all the methods on the builder with a single
      <Tab>, including all the relevant documentation.
    - Easier integration testing. Just compare the config object with your
      expectations instead of intercepting the arguments used for the
      fragment creation.


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/passy/android-directorychooser/60)
<!-- Reviewable:end -->
