### PR TITLE
Fixed callback if DialogFragment called from an other Fragment

### DIFF
--- a/library/src/main/java/net/rdrei/android/dirchooser/DirectoryChooserFragment.java
+++ b/library/src/main/java/net/rdrei/android/dirchooser/DirectoryChooserFragment.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.DialogFragment;
+import android.app.Fragment;
 import android.content.DialogInterface;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
@@ -256,9 +257,14 @@ public class DirectoryChooserFragment extends DialogFragment {
     @Override
     public void onAttach(final Activity activity) {
         super.onAttach(activity);
-        try {
+
+        if (activity instanceof OnFragmentInteractionListener) {
             mListener = Option.some((OnFragmentInteractionListener) activity);
-        } catch (final ClassCastException ignore) {
+        } else {
+            Fragment owner = getTargetFragment();
+            if (owner instanceof OnFragmentInteractionListener) {
+                mListener = Option.some((OnFragmentInteractionListener) owner);
+            }
         }
     }
 


### PR DESCRIPTION
Here are the sole changes to enable that a Fragment ("parent") gets the callbacks from a DirectoryChooserFragment.

`setTargetFragment(callbackFragment, REQUEST_CODE);` must be called for the newly created DirectoryChooserFragment.

Do you want the sample-project to be updated as well?
Not really necessary i think.

Will you make a new library-release and push to Maven Central, please? 