### PR TITLE
Enabled skip-parent functionality to allow navigation to root fix #75

### DIFF
--- a/library/src/main/java/net/rdrei/android/dirchooser/DirectoryChooserFragment.java
+++ b/library/src/main/java/net/rdrei/android/dirchooser/DirectoryChooserFragment.java
@@ -420,6 +420,8 @@ public class DirectoryChooserFragment extends DialogFragment {
                 mFileObserver.startWatching();
                 debug("Changed directory to %s", dir.getAbsolutePath());
             } else {
+                // Try to skip this element (e.g. /sdcard/emulated) to be able to navigate to /
+                changeDirectory(dir.getParentFile());
                 debug("Could not change folder: contents of dir were null");
             }
         }


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the [Contribution Guidelines](https://github.com/passy/Android-DirectoryChooser/CONTRIBUTING.md) 
- [ ] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
- [x] My contribution is fully baked and ready to be merged as is

----------

### Description
It's a rough draft to overcome limitations that one can no longer navigate higher than the root-path of the internal SD-card on current Android-Versions (>4.4, on some devices >5) as described in #75. By skipping a parent directory, that one has no access to, this functionality is restored. 