### PR TITLE
Update annotation processor for Gradle 3

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     compile 'com.github.frankiesardo:auto-parcel:0.3.1'
     compile 'com.google.auto.value:auto-value:1.1'
     annotationProcessor 'com.github.frankiesardo:auto-parcel-processor:0.3.1'
+    compile 'com.github.frankiesardo:auto-parcel-processor:0.3.1'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-all:1.9.5'


### PR DESCRIPTION
This fixes a `Annotation processors must be explicitly declared now.` error when trying to use Gradle 3

https://developer.android.com/studio/build/gradle-plugin-3-0-0-migration.html#annotationProcessor_config
https://stackoverflow.com/questions/42993587/setting-explict-annotation-processor

### Contributor checklist
<!-- mark with x between the brackets -->
- [ ] I have read the [Contribution Guidelines](https://github.com/passy/Android-DirectoryChooser/CONTRIBUTING.md)
- [ ] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
- [ ] My contribution is fully baked and ready to be merged as is

----------

### Description
