### PR TITLE
Fix Read-only selection.

### DIFF
--- a/library/src/main/java/net/rdrei/android/dirchooser/DirectoryChooserFragment.java
+++ b/library/src/main/java/net/rdrei/android/dirchooser/DirectoryChooserFragment.java
@@ -525,7 +525,7 @@ public class DirectoryChooserFragment extends DialogFragment {
      */
     private boolean isValidFile(final File file) {
         return (file != null && file.isDirectory() && file.canRead() &&
-                (mConfig.allowNewDirectoryNameModification() || file.canWrite()));
+                (mConfig.allowReadOnlyDirectory() || file.canWrite()));
     }
 
     @Nullable


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read the [Contribution Guidelines](https://github.com/passy/Android-DirectoryChooser/CONTRIBUTING.md)
- [x] My commit messages follow the [Conventional Commit Message Format](https://gist.github.com/stephenparish/9941e89d80e2bc58a153#format-of-the-commit-message)
- [x] My contribution is fully baked and ready to be merged as is

----------

### Description

fix(Read-only): Read-only feature was not working.
The `allowReadOnlyDirectory()` in `DirectoryChooserConfig`  was unused.
